### PR TITLE
Refactor comic parser to be extension-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export XANDER_TVDB_API_KEY=your-api-key
 
 ### Comic Metadata
 
-Get metadata for files with comic-like filenames using the ComicVine API:
+Get metadata for files with comic-like filenames using the ComicVine API (any file extension is supported):
 
 ```bash
 # Process a single file

--- a/cmd/comic.go
+++ b/cmd/comic.go
@@ -17,10 +17,11 @@ var (
 
 var comicCmd = &cobra.Command{
 	Use:   "comic [filenames]",
-	Short: "Get metadata for comic files",
+	Short: "Get comic metadata for files",
 	Long: `Get metadata for files with comic-like filenames using ComicVine API.
 Files can be provided as arguments or read from a file using the --input flag.
-Filenames should follow format: "Series (Year) #Issue" or "Publisher - Series (Year) #Issue".`,
+Filenames should follow format: "Series (Year) #Issue" or "Publisher - Series (Year) #Issue".
+File extensions are ignored, so any file that follows the naming pattern can be processed.`,
 	Run: runComicCmd,
 }
 

--- a/internal/comicvine/service.go
+++ b/internal/comicvine/service.go
@@ -63,16 +63,24 @@ func (s *ComicService) GetMetadata(filename string) (*Result, error) {
 // GetMetadataForFiles processes multiple files and returns their metadata
 func (s *ComicService) GetMetadataForFiles(filenames []string) ([]*Result, error) {
 	var results []*Result
+	var errors []string
 
 	for _, filename := range filenames {
 		result, err := s.GetMetadata(filename)
 		if err != nil {
 			// Log error but continue with other files
-			fmt.Printf("Error processing %s: %v\n", filename, err)
+			errorMsg := fmt.Sprintf("Error processing %s: %v", filename, err)
+			fmt.Println(errorMsg)
+			errors = append(errors, errorMsg)
 			continue
 		}
 
 		results = append(results, result)
+	}
+
+	// Only return error if no results were found
+	if len(results) == 0 && len(errors) > 0 {
+		return nil, fmt.Errorf("failed to process any files: %s", strings.Join(errors, "; "))
 	}
 
 	return results, nil

--- a/internal/parse/comic.go
+++ b/internal/parse/comic.go
@@ -9,8 +9,7 @@ import (
 
 // Common errors
 var (
-	ErrNotComicFile     = errors.New("not a comic file")
-	ErrInvalidFilename  = errors.New("invalid comic filename format")
+	ErrInvalidFilename = errors.New("invalid comic filename format")
 )
 
 // IsComicFile checks if the filename has a comic file extension
@@ -20,7 +19,7 @@ func IsComicFile(filename string) bool {
 }
 
 // ParseComicFilename extracts series, issue, year, and publisher information from a filename
-// This function accepts any filename regardless of extension
+// This function accepts any string that follows comic naming patterns regardless of extension
 func ParseComicFilename(filename string) (series, issue, year, publisher string, err error) {
 	// Remove the extension (if any)
 	baseFilename := strings.TrimSuffix(filename, filepath.Ext(filename))


### PR DESCRIPTION
This PR improves the comic filename parser:
- Remove extension validation check in ParseComicFilename
- Enhance error handling in ComicService.GetMetadataForFiles
- Update command descriptions to clarify extension handling
- Update README to document extension-agnostic behavior

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>