### PR TITLE
Add unit tests for essential functionality

### DIFF
--- a/comicvine/client_test.go
+++ b/comicvine/client_test.go
@@ -1,0 +1,119 @@
+package comicvine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"comic-parser/config"
+	"comic-parser/models"
+)
+
+func TestNormalizeIssueNumber(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"1", "1"},
+		{"01", "1"},
+		{"001", "1"},
+		{"#1", "1"},
+		{"#001", "1"},
+		{"1.1", "1.1"},
+		{"  1  ", "1"},
+		{"0", "0"},
+		{"", "0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Input_%s", tt.input), func(t *testing.T) {
+			got := normalizeIssueNumber(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeIssueNumber(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	cfg := &config.Config{
+		ComicVineAPIKey:     "test-key",
+		ComicVineAPIBaseURL: "http://example.com",
+	}
+
+	client := NewClient(cfg)
+	defer client.Close()
+
+	if client.apiKey != "test-key" {
+		t.Errorf("NewClient().apiKey = %s; want test-key", client.apiKey)
+	}
+	if client.baseURL != "http://example.com" {
+		t.Errorf("NewClient().baseURL = %s; want http://example.com", client.baseURL)
+	}
+	if client.httpClient == nil {
+		t.Error("NewClient().httpClient is nil")
+	}
+	if client.volumeCache == nil {
+		t.Error("NewClient().volumeCache is nil")
+	}
+}
+
+func TestSearchVolumes(t *testing.T) {
+	// Mock server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		if r.URL.Path != "/search/" {
+			t.Errorf("Expected path /search/, got %s", r.URL.Path)
+		}
+		query := r.URL.Query()
+		if query.Get("api_key") != "test-key" {
+			t.Errorf("Expected api_key test-key, got %s", query.Get("api_key"))
+		}
+		if query.Get("query") != "Test Volume" {
+			t.Errorf("Expected query 'Test Volume', got %s", query.Get("query"))
+		}
+		if query.Get("resources") != "volume" {
+			t.Errorf("Expected resources volume, got %s", query.Get("resources"))
+		}
+
+		// Mock response
+		resp := struct {
+			Results []models.ComicVineVolume `json:"results"`
+		}{
+			Results: []models.ComicVineVolume{
+				{ID: 100, Name: "Test Volume", StartYear: "2020"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	cfg := &config.Config{
+		ComicVineAPIKey:     "test-key",
+		ComicVineAPIBaseURL: ts.URL,
+	}
+
+	client := NewClient(cfg)
+	defer client.Close()
+
+	// Speed up rate limiter for test
+	client.rateLimiter.Stop()
+	client.rateLimiter = time.NewTicker(1 * time.Millisecond)
+
+	ctx := context.Background()
+	results, err := client.searchVolumes(ctx, "Test Volume")
+	if err != nil {
+		t.Fatalf("searchVolumes failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(results))
+	}
+	if results[0].Name != "Test Volume" {
+		t.Errorf("Expected volume name 'Test Volume', got %s", results[0].Name)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.WorkerCount != defaultWorkerCount {
+		t.Errorf("DefaultConfig().WorkerCount = %d; want %d", cfg.WorkerCount, defaultWorkerCount)
+	}
+	if cfg.AnthropicModel != defaultAnthropicModel {
+		t.Errorf("DefaultConfig().AnthropicModel = %s; want %s", cfg.AnthropicModel, defaultAnthropicModel)
+	}
+	if cfg.CacheEnabled != true {
+		t.Error("DefaultConfig().CacheEnabled = false; want true")
+	}
+}
+
+func TestLoadFromEnv(t *testing.T) {
+	// Save current env vars
+	oldAnthropic := os.Getenv(envAnthropicAPIKey)
+	oldCV := os.Getenv(envComicVineAPIKey)
+	defer func() {
+		os.Setenv(envAnthropicAPIKey, oldAnthropic)
+		os.Setenv(envComicVineAPIKey, oldCV)
+	}()
+
+	// Set test env vars
+	testAnthropicKey := "test-anthropic-key"
+	testCVKey := "test-cv-key"
+	os.Setenv(envAnthropicAPIKey, testAnthropicKey)
+	os.Setenv(envComicVineAPIKey, testCVKey)
+
+	cfg := DefaultConfig()
+	cfg.LoadFromEnv()
+
+	if cfg.AnthropicAPIKey != testAnthropicKey {
+		t.Errorf("LoadFromEnv() AnthropicAPIKey = %s; want %s", cfg.AnthropicAPIKey, testAnthropicKey)
+	}
+	if cfg.ComicVineAPIKey != testCVKey {
+		t.Errorf("LoadFromEnv() ComicVineAPIKey = %s; want %s", cfg.ComicVineAPIKey, testCVKey)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name: "Valid Config",
+			config: &Config{
+				AnthropicAPIKey: "key1",
+				ComicVineAPIKey: "key2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing Anthropic Key",
+			config: &Config{
+				AnthropicAPIKey: "",
+				ComicVineAPIKey: "key2",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing ComicVine Key",
+			config: &Config{
+				AnthropicAPIKey: "key1",
+				ComicVineAPIKey: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/prompts/prompts_test.go
+++ b/prompts/prompts_test.go
@@ -1,0 +1,70 @@
+package prompts
+
+import (
+	"strings"
+	"testing"
+
+	"comic-parser/models"
+)
+
+func TestFilenameParsePrompt(t *testing.T) {
+	filename := "Test Comic 001.cbz"
+	prompt := FilenameParsePrompt(filename)
+
+	if !strings.Contains(prompt, filename) {
+		t.Errorf("FilenameParsePrompt() does not contain filename %q", filename)
+	}
+	if !strings.Contains(prompt, "FILENAME TO PARSE:") {
+		t.Error("FilenameParsePrompt() missing 'FILENAME TO PARSE:' label")
+	}
+	if !strings.Contains(prompt, "Respond with ONLY a JSON object") {
+		t.Error("FilenameParsePrompt() missing JSON instruction")
+	}
+}
+
+func TestResultMatchPrompt(t *testing.T) {
+	parsed := models.ParsedFilename{
+		OriginalFilename: "Test Comic 001.cbz",
+		Title:            "Test Comic",
+		IssueNumber:      "1",
+		Year:             "2023",
+		Publisher:        "TestPub",
+		VolumeNumber:     "v1",
+		Notes:            "Some notes",
+	}
+
+	results := []models.ComicVineIssue{
+		{
+			ID:          123,
+			Name:        "Test Comic",
+			IssueNumber: "1",
+			Volume: models.VolumeRef{
+				Name: "Test Comic",
+			},
+		},
+	}
+
+	prompt := ResultMatchPrompt(parsed, results)
+
+	// Check parsed info presence
+	if !strings.Contains(prompt, parsed.OriginalFilename) {
+		t.Error("ResultMatchPrompt() missing OriginalFilename")
+	}
+	if !strings.Contains(prompt, parsed.Title) {
+		t.Error("ResultMatchPrompt() missing Title")
+	}
+	if !strings.Contains(prompt, parsed.IssueNumber) {
+		t.Error("ResultMatchPrompt() missing IssueNumber")
+	}
+	if !strings.Contains(prompt, parsed.Year) {
+		t.Error("ResultMatchPrompt() missing Year")
+	}
+	if !strings.Contains(prompt, parsed.Publisher) {
+		t.Error("ResultMatchPrompt() missing Publisher")
+	}
+
+	// Check results presence (partial check via ID)
+	if !strings.Contains(prompt, "123") {
+		t.Error("ResultMatchPrompt() missing result ID")
+	}
+}


### PR DESCRIPTION
- Added `config/config_test.go` to test configuration loading, validation, and environment variable overrides.
- Added `comicvine/client_test.go` to test issue normalization, client initialization, and volume search (mocked).
- Added `prompts/prompts_test.go` to verify prompt generation includes input data.
- Verified all tests pass with `go test ./...`.