### PR TITLE
Implement modular ResultSelector with TUI support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	OutputFile   string `json:"output_file"`
 	OutputFormat string `json:"output_format"` // json, csv
 	Verbose      bool   `json:"verbose"`
+	Interactive  bool   `json:"interactive"`
 }
 
 // DefaultConfig returns a configuration with sensible defaults.
@@ -77,6 +78,7 @@ func DefaultConfig() *Config {
 		OutputFile:          defaultOutputFile,
 		OutputFormat:        defaultOutputFormat,
 		Verbose:             false,
+		Interactive:         false,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	configFile := flag.String("config", "config.json", "Path to configuration file")
 	workers := flag.Int("workers", 3, "Number of concurrent workers")
 	verbose := flag.Bool("verbose", false, "Enable verbose logging")
+	interactive := flag.Bool("interactive", false, "Enable interactive TUI mode")
 	singleFile := flag.String("file", "", "Process a single filename (for testing)")
 	generateConfig := flag.Bool("generate-config", false, "Generate a sample config file")
 
@@ -64,6 +65,7 @@ func main() {
 		cfg.OutputFormat = *outputFormat
 	}
 	cfg.Verbose = *verbose
+	cfg.Interactive = *interactive
 
 	// Validate configuration
 	if err := cfg.Validate(); err != nil {

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"comic-parser/config"
 	"comic-parser/models"
+	"comic-parser/selector"
 )
 
 // MockLLMClient
@@ -49,6 +50,7 @@ func TestProcessFile(t *testing.T) {
 		llmClient: mockLLM,
 		cvClient:  mockCV,
 		verbose:   true,
+		selector:  selector.NewLLMSelector(mockLLM, cfg),
 	}
 
 	// Mock LLM responses
@@ -116,6 +118,7 @@ func TestProcessFile_ParseError(t *testing.T) {
 		cfg:       cfg,
 		llmClient: mockLLM,
 		cvClient:  mockCV,
+		selector:  selector.NewLLMSelector(mockLLM, cfg),
 	}
 
 	mockLLM.CompleteWithRetryFunc = func(ctx context.Context, prompt string, maxRetries int, delay time.Duration) (string, error) {

--- a/selector/llm.go
+++ b/selector/llm.go
@@ -1,0 +1,73 @@
+package selector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"comic-parser/config"
+	"comic-parser/llm"
+	"comic-parser/models"
+	"comic-parser/prompts"
+)
+
+// LLMSelector uses an LLM to select the best match from candidates.
+type LLMSelector struct {
+	client LLMClient
+	cfg    *config.Config
+}
+
+// NewLLMSelector creates a new LLMSelector.
+func NewLLMSelector(client LLMClient, cfg *config.Config) *LLMSelector {
+	return &LLMSelector{
+		client: client,
+		cfg:    cfg,
+	}
+}
+
+// Select implements the Selector interface.
+func (s *LLMSelector) Select(ctx context.Context, parsed *models.ParsedFilename, issues []models.ComicVineIssue) (*models.MatchResult, error) {
+	result := &models.MatchResult{
+		OriginalFilename: parsed.OriginalFilename,
+		ParsedInfo:       *parsed,
+	}
+
+	if len(issues) == 0 {
+		result.MatchConfidence = "none"
+		result.Reasoning = "No results found in ComicVine"
+		return result, nil
+	}
+
+	prompt := prompts.ResultMatchPrompt(*parsed, issues)
+
+	response, err := s.client.CompleteWithRetry(
+		ctx,
+		prompt,
+		s.cfg.RetryAttempts,
+		time.Duration(s.cfg.RetryDelaySeconds)*time.Second,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("LLM completion: %w", err)
+	}
+
+	// Extract JSON from response
+	jsonStr := llm.ExtractJSON(response)
+
+	var matchResp prompts.MatchResponse
+	if err := json.Unmarshal([]byte(jsonStr), &matchResp); err != nil {
+		return nil, fmt.Errorf("parsing LLM response: %w (response: %s)", err, response)
+	}
+
+	result.MatchConfidence = matchResp.MatchConfidence
+	result.Reasoning = matchResp.Reasoning
+
+	if matchResp.SelectedIndex >= 0 && matchResp.SelectedIndex < len(issues) {
+		selectedIssue := issues[matchResp.SelectedIndex]
+		result.SelectedIssue = &selectedIssue
+		result.ComicVineID = selectedIssue.ID
+		result.ComicVineURL = selectedIssue.SiteDetailURL
+	}
+
+	return result, nil
+}

--- a/selector/selector.go
+++ b/selector/selector.go
@@ -1,0 +1,18 @@
+package selector
+
+import (
+	"context"
+	"time"
+
+	"comic-parser/models"
+)
+
+// Selector defines the interface for selecting a match from ComicVine results.
+type Selector interface {
+	Select(ctx context.Context, parsed *models.ParsedFilename, candidates []models.ComicVineIssue) (*models.MatchResult, error)
+}
+
+// LLMClient defines the interface for LLM interactions needed by LLMSelector.
+type LLMClient interface {
+	CompleteWithRetry(ctx context.Context, prompt string, maxRetries int, delay time.Duration) (string, error)
+}

--- a/selector/tui.go
+++ b/selector/tui.go
@@ -1,0 +1,94 @@
+package selector
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"comic-parser/models"
+)
+
+// TUISelector presents candidates to the user via CLI.
+type TUISelector struct {
+	mu sync.Mutex
+}
+
+// NewTUISelector creates a new TUISelector.
+func NewTUISelector() *TUISelector {
+	return &TUISelector{}
+}
+
+// Select implements the Selector interface.
+func (s *TUISelector) Select(ctx context.Context, parsed *models.ParsedFilename, issues []models.ComicVineIssue) (*models.MatchResult, error) {
+	// Lock to ensure only one interaction happens at a time
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := &models.MatchResult{
+		OriginalFilename: parsed.OriginalFilename,
+		ParsedInfo:       *parsed,
+	}
+
+	if len(issues) == 0 {
+		fmt.Printf("\n--- No Results Found ---\n")
+		fmt.Printf("File: %s\n", parsed.OriginalFilename)
+		fmt.Printf("Parsed: %s #%s (%s)\n", parsed.Title, parsed.IssueNumber, parsed.Year)
+		fmt.Println("No candidates returned from ComicVine.")
+		fmt.Println("Press Enter to continue...")
+		bufio.NewReader(os.Stdin).ReadBytes('\n')
+
+		result.MatchConfidence = "none"
+		result.Reasoning = "No results found in ComicVine"
+		return result, nil
+	}
+
+	fmt.Printf("\n==================================================\n")
+	fmt.Printf("File: %s\n", parsed.OriginalFilename)
+	fmt.Printf("Parsed: Title='%s' Issue='%s' Year='%s' Publisher='%s'\n",
+		parsed.Title, parsed.IssueNumber, parsed.Year, parsed.Publisher)
+	fmt.Printf("--------------------------------------------------\n")
+	fmt.Printf("Select a match (0 for No Match):\n")
+
+	for i, issue := range issues {
+		fmt.Printf("[%d] %s #%s (%s) - %s\n",
+			i+1, issue.Volume.Name, issue.IssueNumber, issue.CoverDate, issue.Volume.Publisher)
+	}
+	fmt.Printf("--------------------------------------------------\n")
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("Enter selection [0-", len(issues), "]: ")
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(input)
+
+		val, err := strconv.Atoi(input)
+		if err != nil {
+			fmt.Println("Invalid input. Please enter a number.")
+			continue
+		}
+
+		if val == 0 {
+			result.MatchConfidence = "none"
+			result.Reasoning = "User selected No Match"
+			fmt.Println("Marked as No Match.")
+			return result, nil
+		}
+
+		if val > 0 && val <= len(issues) {
+			selectedIssue := issues[val-1]
+			result.SelectedIssue = &selectedIssue
+			result.ComicVineID = selectedIssue.ID
+			result.ComicVineURL = selectedIssue.SiteDetailURL
+			result.MatchConfidence = "high" // User manually selected it
+			result.Reasoning = "User manual selection"
+			fmt.Printf("Selected: %s #%s\n", selectedIssue.Volume.Name, selectedIssue.IssueNumber)
+			return result, nil
+		}
+
+		fmt.Println("Selection out of range.")
+	}
+}

--- a/selector/tui_test.go
+++ b/selector/tui_test.go
@@ -1,0 +1,131 @@
+package selector
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"comic-parser/models"
+)
+
+func TestTUISelector_Select(t *testing.T) {
+	// Create a pipe to mock stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+
+	// Save original stdin
+	oldStdin := os.Stdin
+	defer func() {
+		os.Stdin = oldStdin
+		w.Close()
+	}()
+
+	// Set stdin to our pipe
+	os.Stdin = r
+
+	// Simulate user input
+	// "1\n" selects the first item
+	go func() {
+		time.Sleep(100 * time.Millisecond) // Give time for output to print
+		w.Write([]byte("1\n"))
+	}()
+
+	parsed := &models.ParsedFilename{
+		OriginalFilename: "Test Comic 001.cbz",
+		Title:            "Test Comic",
+		IssueNumber:      "1",
+	}
+
+	issues := []models.ComicVineIssue{
+		{
+			ID:          123,
+			Name:        "Test Comic",
+			IssueNumber: "1",
+			Volume: models.VolumeRef{
+				Name: "Test Comic Vol 1",
+			},
+		},
+		{
+			ID:          456,
+			Name:        "Test Comic",
+			IssueNumber: "2",
+			Volume: models.VolumeRef{
+				Name: "Test Comic Vol 1",
+			},
+		},
+	}
+
+	s := NewTUISelector()
+	ctx := context.Background()
+
+	result, err := s.Select(ctx, parsed, issues)
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+
+	if result.SelectedIssue == nil {
+		t.Fatal("Expected a selected issue, got nil")
+	}
+
+	if result.SelectedIssue.ID != 123 {
+		t.Errorf("Expected issue ID 123, got %d", result.SelectedIssue.ID)
+	}
+
+	if result.MatchConfidence != "high" {
+		t.Errorf("Expected high confidence, got %s", result.MatchConfidence)
+	}
+}
+
+func TestTUISelector_NoMatch(t *testing.T) {
+	// Create a pipe to mock stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+
+	// Save original stdin
+	oldStdin := os.Stdin
+	defer func() {
+		os.Stdin = oldStdin
+		w.Close()
+	}()
+
+	// Set stdin to our pipe
+	os.Stdin = r
+
+	// Simulate user input
+	// "0\n" selects No Match
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		w.Write([]byte("0\n"))
+	}()
+
+	parsed := &models.ParsedFilename{
+		OriginalFilename: "Test Comic 001.cbz",
+		Title:            "Test Comic",
+		IssueNumber:      "1",
+	}
+
+	issues := []models.ComicVineIssue{
+		{ID: 123},
+	}
+
+	s := NewTUISelector()
+	ctx := context.Background()
+
+	result, err := s.Select(ctx, parsed, issues)
+	if err != nil {
+		t.Fatalf("Select failed: %v", err)
+	}
+
+	if result.SelectedIssue != nil {
+		t.Errorf("Expected no selected issue, got %v", result.SelectedIssue)
+	}
+
+	if result.MatchConfidence != "none" {
+		t.Errorf("Expected none confidence, got %s", result.MatchConfidence)
+	}
+}


### PR DESCRIPTION
- Refactored `processor` to use a `Selector` interface for match selection.
- Created `selector` package with `LLMSelector` (original behavior) and `TUISelector`.
- Added `-interactive` flag to enable TUI mode.
- `TUISelector` uses a mutex to serialize user input while maintaining background concurrency.
- Added tests for TUI selector.