### PR TITLE
Refactor parsing logic into modular parser package with pipeline support

### DIFF
--- a/internal/comicvine/client.go
+++ b/internal/comicvine/client.go
@@ -37,7 +37,6 @@ const (
 
 	// Volume ID format prefix
 	volumeIDPrefix = "4050-"
-
 )
 
 // HTTPClient defines the interface for making HTTP requests

--- a/internal/parser/chain_parser.go
+++ b/internal/parser/chain_parser.go
@@ -1,0 +1,48 @@
+package parser
+
+import (
+	"context"
+	"strings"
+
+	"comic-parser/internal/models"
+)
+
+// ChainParser combines two parsers: a primary (usually Regex) and a fallback (usually LLM).
+// If the primary parser fails to produce a high-confidence result, the fallback is used.
+type ChainParser struct {
+	primary  Parser
+	fallback Parser
+}
+
+// NewChainParser creates a new ChainParser.
+func NewChainParser(primary Parser, fallback Parser) *ChainParser {
+	return &ChainParser{
+		primary:  primary,
+		fallback: fallback,
+	}
+}
+
+// Parse implements the Parser interface.
+func (p *ChainParser) Parse(ctx context.Context, input *models.ParsedFilename) (*models.ParsedFilename, error) {
+	// Try primary parser
+	result, err := p.primary.Parse(ctx, input)
+
+	// Determine if we need to use the fallback parser
+	shouldFallback := false
+	if err != nil {
+		// If primary errors, we fallback (assuming we want to try the next method)
+		shouldFallback = true
+	} else if result == nil {
+		shouldFallback = true
+	} else if strings.ToLower(result.Confidence) != "high" {
+		shouldFallback = true
+	}
+
+	if shouldFallback {
+		// Execute fallback parser
+		// We pass the original input to ensure a clean attempt
+		return p.fallback.Parse(ctx, input)
+	}
+
+	return result, nil
+}

--- a/internal/parser/llm_parser.go
+++ b/internal/parser/llm_parser.go
@@ -1,0 +1,64 @@
+package parser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"comic-parser/internal/llm"
+	"comic-parser/internal/models"
+	"comic-parser/internal/prompts"
+)
+
+// LLMClient defines the interface for LLM interactions required by the parser.
+type LLMClient interface {
+	CompleteWithRetry(ctx context.Context, prompt string, maxRetries int, delay time.Duration) (string, error)
+}
+
+// LLMParser implements the Parser interface using an LLM.
+type LLMParser struct {
+	client            LLMClient
+	retryAttempts     int
+	retryDelaySeconds int
+}
+
+// NewLLMParser creates a new LLMParser.
+func NewLLMParser(client LLMClient, retryAttempts int, retryDelaySeconds int) *LLMParser {
+	return &LLMParser{
+		client:            client,
+		retryAttempts:     retryAttempts,
+		retryDelaySeconds: retryDelaySeconds,
+	}
+}
+
+// Parse implements the Parser interface.
+// It uses an LLM to parse the filename.
+func (p *LLMParser) Parse(ctx context.Context, input *models.ParsedFilename) (*models.ParsedFilename, error) {
+	prompt := prompts.FilenameParsePrompt(input.OriginalFilename)
+
+	response, err := p.client.CompleteWithRetry(
+		ctx,
+		prompt,
+		p.retryAttempts,
+		time.Duration(p.retryDelaySeconds)*time.Second,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("LLM completion: %w", err)
+	}
+
+	// Extract JSON from response
+	jsonStr := llm.ExtractJSON(response)
+
+	// Create a new struct to hold the result
+	// We unmarshal into a new struct to ensure we get a fresh parse
+	var parsed models.ParsedFilename
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		return nil, fmt.Errorf("parsing LLM response: %w (response: %s)", err, response)
+	}
+
+	// Ensure OriginalFilename is preserved from the input
+	parsed.OriginalFilename = input.OriginalFilename
+
+	return &parsed, nil
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,15 @@
+// Package parser provides interfaces and implementations for parsing comic filenames.
+package parser
+
+import (
+	"context"
+
+	"comic-parser/internal/models"
+)
+
+// Parser defines the interface for parsing comic filenames.
+// It takes a ParsedFilename struct (containing the original filename) and returns
+// a parsed version of it (or a new struct with populated fields).
+type Parser interface {
+	Parse(ctx context.Context, input *models.ParsedFilename) (*models.ParsedFilename, error)
+}

--- a/internal/parser/regex_parser.go
+++ b/internal/parser/regex_parser.go
@@ -1,0 +1,25 @@
+package parser
+
+import (
+	"context"
+
+	"comic-parser/internal/models"
+)
+
+// RegexParser implements the Parser interface using regular expressions.
+// Currently it is a placeholder that passes the input through unchanged.
+type RegexParser struct{}
+
+// NewRegexParser creates a new RegexParser.
+func NewRegexParser() *RegexParser {
+	return &RegexParser{}
+}
+
+// Parse implements the Parser interface.
+// It currently returns the input struct as-is, simulating a low-confidence match
+// or a pass-through behavior.
+func (p *RegexParser) Parse(ctx context.Context, input *models.ParsedFilename) (*models.ParsedFilename, error) {
+	// In the future, this will use regex to extract info.
+	// For now, it just returns the input.
+	return input, nil
+}


### PR DESCRIPTION
Moved parsing logic from Processor to a new internal/parser package. Introduced Parser interface and implemented:
- RegexParser (placeholder/pass-through)
- LLMParser (logic extracted from Processor)
- ChainParser (orchestrates Regex -> LLM fallback based on confidence)

Refactored Processor to use the Parser interface.
Updated main.go to wire up the ChainParser as the default. Updated tests to mock the Parser interface.